### PR TITLE
chore: Update git dependencies to use public paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 wstp-sys = { path = "./wstp-sys" }
 
-wolfram-expr = { git = "ssh://git@stash.wolfram.com:7999/~connorg/wolfram-expr.git" }
+wolfram-expr = { git = "https://github.com/WolframResearch/wolfram-expr-rs" }
 
 lazy_static = "1.4.0"
 ref-cast = "1.0.6"

--- a/wstp-sys/Cargo.toml
+++ b/wstp-sys/Cargo.toml
@@ -12,6 +12,6 @@ links = "WSTPi4"
 [dependencies]
 
 [build-dependencies]
-wolfram-app-discovery = { git = "ssh://git@stash.wolfram.com:7999/~connorg/wolfram-app-discovery.git" }
+wolfram-app-discovery = { git = "https://github.com/WolframResearch/wolfram-app-discovery-rs" }
 
 cfg-if = "0.1.10"


### PR DESCRIPTION
These will be updated again once these repositories are
uploaded to crates.io.