### PR TITLE
feature: Add Expr::get_expr_with_resolver()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fn example() -> Result<(), wstp::Error> {
     let mut buffer = String::new();
 
     for _ in 0 .. link.test_head("System`List")? {
-        buffer.push_str(link.get_string_ref()?.to_str())
+        buffer.push_str(link.get_string_ref()?.as_str())
     }
 
     assert_eq!(buffer, "abc");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! let mut buffer = String::new();
 //!
 //! for _ in 0 .. link.test_head("System`List")? {
-//!     buffer.push_str(link.get_string_ref()?.to_str())
+//!     buffer.push_str(link.get_string_ref()?.as_str())
 //! }
 //!
 //! assert_eq!(buffer, "abc");

--- a/tests/test_links.rs
+++ b/tests/test_links.rs
@@ -59,7 +59,7 @@ fn check_send_data_across_link(mut link_a: Link, mut link_b: Link) {
         {
             assert_eq!(link_b.get_raw_type(), Ok(i32::from(sys::WSTKFUNC)));
             assert_eq!(link_b.get_arg_count(), Ok(2));
-            assert!(link_b.get_symbol_ref().unwrap().to_str() == "Sin");
+            assert!(link_b.get_symbol_ref().unwrap().as_str() == "Sin");
             assert_eq!(link_b.get_f64(), Ok(1.0))
         }
 

--- a/tests/test_loopback_links.rs
+++ b/tests/test_loopback_links.rs
@@ -32,7 +32,7 @@ fn test_loopback_get_put_atoms() {
         // Test the `Link::get_string_ref()` method.
         link.put_expr(&Expr::string("Hello!")).unwrap();
         let link_str: LinkStr = link.get_string_ref().unwrap();
-        assert_eq!(link_str.to_str(), "Hello!")
+        assert_eq!(link_str.as_str(), "Hello!")
     }
 
     {
@@ -40,7 +40,7 @@ fn test_loopback_get_put_atoms() {
         link.put_expr(&Expr::symbol(Symbol::new("System`Plot")))
             .unwrap();
         let link_str: LinkStr = link.get_symbol_ref().unwrap();
-        assert_eq!(link_str.to_str(), "System`Plot")
+        assert_eq!(link_str.as_str(), "System`Plot")
     }
 }
 
@@ -68,7 +68,7 @@ fn test_loopback_idempotence_of_get_arg_count() {
     }
 
     assert_eq!(
-        link.get_string_ref().map(|s| s.to_str().to_owned()),
+        link.get_string_ref().map(|s| s.as_str().to_owned()),
         Ok(String::from("List"))
     );
 }
@@ -104,7 +104,7 @@ fn test_loopback_basic_put_and_get_list() {
     assert_eq!(link.raw_get_next(), Ok(sys::WSTKFUNC.into()));
     assert_eq!(link.get_arg_count(), Ok(1));
     assert_eq!(
-        link.get_string_ref().map(|s| s.to_str().to_owned()),
+        link.get_string_ref().map(|s| s.as_str().to_owned()),
         Ok(String::from("List"))
     );
     assert_eq!(link.get_i64(), Ok(10));
@@ -176,7 +176,7 @@ fn test_loopback_transfer_simple() {
     let mut new = Link::new_loopback().unwrap();
     link.transfer_to_end_of_loopback_link(&mut new).unwrap();
 
-    assert_eq!(new.get_string_ref().unwrap().to_str(), "hello");
+    assert_eq!(new.get_string_ref().unwrap().as_str(), "hello");
 }
 
 #[test]


### PR DESCRIPTION
This is an experimental feature intended to provide a workaround for the problem that the Wolfram Kernel does not always write symbol expressions with their complete context.

For example, the symbol System`List may be written as the string "List" and not "System`List". That means that the context of "List" is ambiguous when being read off of the link by `Link::get_expr()`.

Link::get_expr_with_resolver() works around this problem by using a user-provided callback function to handle any ambiguous symbols. The user function can choose how to handle them. Doing this in a naive way (e.g. assuming every ambiguous symbol is in the System` context) is a hacky workaround, but sufficient for simple use-cases.

A more robust method would be to ask the Kernel explicitly for the context, e.g. by evaluating `Context["List"]`. But that has performance considerations, and is not easy to do in the middle of `get_expr()`.