### PR TITLE
feature: Compile-time generation of WSTP bindings

### DIFF
--- a/wstp-sys/Cargo.toml
+++ b/wstp-sys/Cargo.toml
@@ -19,3 +19,4 @@ link-cplusplus = "1.0.6"
 
 [build-dependencies]
 wolfram-app-discovery = "0.2.1"
+bindgen = "0.59.2"

--- a/wstp-sys/build.rs
+++ b/wstp-sys/build.rs
@@ -52,61 +52,7 @@ fn main() {
     // Link to WSTP
     //-------------
 
-    // Path to the WSTP static library file.
-    let static_lib = &app
-        .wstp_static_library_path()
-        .expect("unable to get WSTP static library path");
-
-    link_wstp_statically(&static_lib);
-
-    //
-    // Link to the C++ standard library, required by WSTP
-    //
-
-    // Note: This is now handled by the `link-cplusplus` crate dependency.
-
-    // Note: This blog post explained this, and that this might need to change on Linux.
-    //         https://flames-of-code.netlify.com/blog/rust-and-cmake-cplusplus/
-    // println!("cargo:rustc-link-lib=dylib=c++");
-
-    //-----------------------------------
-    // Link to WSTP "interface" libraries
-    //-----------------------------------
-
-    // The CompilerAdditions/WSTP-targets.cmake file describes the dependencies
-    // of the WSTP library that must be linked into the final artifact for any
-    // code that depends on WSTP. (The contents of that file differ on each
-    // platform). They are the `INTERFACE_LINK_LIBRARIES` of the
-    // `WSTP::STATIC_LIBRARY` CMake target.
-    //
-    // On macOS, the Foundation framework is the only dependency. On Windows,
-    // several system libraries must be linked.
-    //
-    // FIXME: Update this logic to cover the Linux interface libraries.
-
-    //
-    // macOS
-    //
-
-    // TODO: Look at the complete list of CMake libraries required by WSTP and update this
-    //       logic for Windows and Linux.
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-lib=framework=Foundation");
-    }
-
-    //
-    // Windows
-    //
-
-    if cfg!(target_os = "windows") {
-        println!("cargo:rustc-link-lib=dylib=kernel32");
-        println!("cargo:rustc-link-lib=dylib=user32");
-        println!("cargo:rustc-link-lib=dylib=advapi32");
-        println!("cargo:rustc-link-lib=dylib=comdlg32");
-        println!("cargo:rustc-link-lib=dylib=ws2_32");
-        println!("cargo:rustc-link-lib=dylib=wsock32");
-        println!("cargo:rustc-link-lib=dylib=rpcrt4");
-    }
+    link_to_wstp(&app);
 
     //---------------------------------------------------------------
     // Choose the pre-generated bindings to use for the target system
@@ -165,6 +111,71 @@ fn make_bindings_path(wolfram_version: &str, system_id: &str) -> PathBuf {
         .join("WSTP_bindings.rs");
 
     bindings_path
+}
+
+//======================================
+// Link to WSTP
+//======================================
+
+/// Emits the necessary `cargo` instructions to link to the WSTP static library,
+/// and also links the WSTP interface libraries (the libraries that WSTP itself
+/// depends on).
+fn link_to_wstp(app: &WolframApp) {
+    // Path to the WSTP static library file.
+    let static_lib = &app
+        .wstp_static_library_path()
+        .expect("unable to get WSTP static library path");
+
+    link_wstp_statically(&static_lib);
+
+    //
+    // Link to the C++ standard library, required by WSTP
+    //
+
+    // Note: This is now handled by the `link-cplusplus` crate dependency.
+
+    // Note: This blog post explained this, and that this might need to change on Linux.
+    //         https://flames-of-code.netlify.com/blog/rust-and-cmake-cplusplus/
+    // println!("cargo:rustc-link-lib=dylib=c++");
+
+    //-----------------------------------
+    // Link to WSTP "interface" libraries
+    //-----------------------------------
+
+    // The CompilerAdditions/WSTP-targets.cmake file describes the dependencies
+    // of the WSTP library that must be linked into the final artifact for any
+    // code that depends on WSTP. (The contents of that file differ on each
+    // platform). They are the `INTERFACE_LINK_LIBRARIES` of the
+    // `WSTP::STATIC_LIBRARY` CMake target.
+    //
+    // On macOS, the Foundation framework is the only dependency. On Windows,
+    // several system libraries must be linked.
+    //
+    // FIXME: Update this logic to cover the Linux interface libraries.
+
+    //
+    // macOS
+    //
+
+    // TODO: Look at the complete list of CMake libraries required by WSTP and update this
+    //       logic for Windows and Linux.
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+    }
+
+    //
+    // Windows
+    //
+
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=dylib=kernel32");
+        println!("cargo:rustc-link-lib=dylib=user32");
+        println!("cargo:rustc-link-lib=dylib=advapi32");
+        println!("cargo:rustc-link-lib=dylib=comdlg32");
+        println!("cargo:rustc-link-lib=dylib=ws2_32");
+        println!("cargo:rustc-link-lib=dylib=wsock32");
+        println!("cargo:rustc-link-lib=dylib=rpcrt4");
+    }
 }
 
 fn link_wstp_statically(lib: &PathBuf) {

--- a/wstp-sys/build.rs
+++ b/wstp-sys/build.rs
@@ -49,7 +49,6 @@ fn main() {
     }
 
 
-
     let app = WolframApp::try_default().expect("unable to locate WolframApp");
 
     //-------------
@@ -96,11 +95,17 @@ fn main() {
 
 /// Use bindings that we generate now at compile time.
 fn use_generated_bindings(app: &WolframApp) -> PathBuf {
-    let wstp_h = app.wstp_c_header_path().expect("unable to get 'wstp.h' location");
+    let wstp_h = app
+        .wstp_c_header_path()
+        .expect("unable to get 'wstp.h' location");
 
-    println!("cargo:warning=info: generating WSTP bindings from: {}", wstp_h.display());
+    println!(
+        "cargo:warning=info: generating WSTP bindings from: {}",
+        wstp_h.display()
+    );
 
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("WSTP_bindings.rs");
+    let out_path =
+        PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("WSTP_bindings.rs");
 
     generate_and_save_bindings_to_file(&wstp_h, &out_path);
 

--- a/wstp-sys/build.rs
+++ b/wstp-sys/build.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 use std::process;
 
-use wolfram_app_discovery::WolframApp;
+use wolfram_app_discovery::{WolframApp, WolframVersion};
 
 fn main() {
     // This crate is being built by docs.rs. Skip trying to locate a WolframApp.
@@ -63,6 +63,15 @@ fn main() {
     let wolfram_version = app
         .wolfram_version()
         .expect("unable to get Wolfram Language vesion number");
+
+    use_pregenerated_bindings(&wolfram_version);
+}
+
+//========================================================================
+// Tell `lib.rs` where to find the file containing the WSTP Rust bindings.
+//========================================================================
+
+fn use_pregenerated_bindings(wolfram_version: &WolframVersion) {
     let system_id =
         wolfram_app_discovery::system_id_from_target(&std::env::var("TARGET").unwrap())
             .expect("unable to get System ID for target system");

--- a/wstp-sys/build.rs
+++ b/wstp-sys/build.rs
@@ -11,6 +11,10 @@ use std::process;
 use wolfram_app_discovery::{WolframApp, WolframVersion};
 
 fn main() {
+    // Ensure that changes to environment variables checked by wolfram-app-discovery will
+    // cause cargo to rebuild the current crate.
+    wolfram_app_discovery::config::set_print_cargo_build_script_instructions(true);
+
     // This crate is being built by docs.rs. Skip trying to locate a WolframApp.
     // See: https://docs.rs/about/builds#detecting-docsrs
     if std::env::var("DOCS_RS").is_ok() {

--- a/wstp-sys/src/lib.rs
+++ b/wstp-sys/src/lib.rs
@@ -10,4 +10,4 @@ extern crate link_cplusplus;
 
 
 // The name of this file comes from `build.rs`.
-include!(concat!("../", env!("CRATE_WSTP_SYS_BINDINGS")));
+include!(env!("CRATE_WSTP_SYS_BINDINGS"));


### PR DESCRIPTION
Prior to this, wstp-sys has been using bindings to wstp.h that were
pre-generated. This required using the `generate-versioned-bindings.rs`
script to create a new file for each `{<System ID>, <Wolfram Language version>}`
combination that wstp-sys wanted to support. This was fragile and time
consuming, and inevitably always out of date.

Using pre-generated bindings made some sense before
wolfram-app-discovery was written, but it makes little sense now.

There is a small compile-time tradeoff to doing this: the compile time
of wstp-sys now includes the time needed to compile the new `bindgen`
dependency, and the time to use bindgen to generate the WSTP Rust
bindings file. However, the maintenance and "it actually works" benefits
I think outweigh that consideration.

I've left the pre-generated bindings files and code in place for now.
At the very least, a minimal version of that logic is needed long-term
so that `wstp-sys` can be built successfully in the docs.rs built
environment (where we don't have access to a WSTP SDK to generate the
bindings on the fly).

It's possible it may make sense to enable usage of pre-generated
bindings using a cargo feature. More experience with real-world usage is
needed.