### PR TITLE
docs: Mention get_u8_array() in the Array type doc comment

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -792,6 +792,7 @@ unsafe impl LinkStrType for Utf32Str {
 /// * [`Link::get_i64_array()`]
 /// * [`Link::get_i32_array()`]
 /// * [`Link::get_i16_array()`]
+/// * [`Link::get_u8_array()`]
 /// * [`Link::get_f64_array()`]
 /// * [`Link::get_f32_array()`]
 pub struct Array<'link, T> {


### PR DESCRIPTION
A raw u8 array is useful for passing arbitrary binary blobs
of data via WSTP, so this is a particularly useful method to
highlight.