### PR TITLE
chore: Update wolfram-app-discovery dependency from 0.2.1 to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ ref-cast = "1.0.6"
 
 [dev-dependencies]
 rand = "0.8.3"
-wolfram-app-discovery = "0.2.1"
+wolfram-app-discovery = "0.3.0"

--- a/src/get.rs
+++ b/src/get.rs
@@ -609,7 +609,7 @@ impl Link {
         Ok(Array {
             link: self,
             data_ptr,
-            release_callback: Box::new(move |link: &Link| unsafe {
+            release_callback: Box::new(move |link: &Link| {
                 WSReleaseTArray(
                     link.raw_link,
                     data_ptr,

--- a/wstp-sys/Cargo.toml
+++ b/wstp-sys/Cargo.toml
@@ -18,5 +18,5 @@ links = "WSTPi4"
 link-cplusplus = "1.0.6"
 
 [build-dependencies]
-wolfram-app-discovery = "0.2.1"
+wolfram-app-discovery = "0.3.0"
 bindgen = "0.59.2"

--- a/wstp-sys/scripts/generate-versioned-bindings.rs
+++ b/wstp-sys/scripts/generate-versioned-bindings.rs
@@ -4,7 +4,7 @@
 //!
 //! [dependencies]
 //! bindgen = "^0.58.1"
-//! wolfram-app-discovery = "0.2.1"
+//! wolfram-app-discovery = "0.3.0"
 //! ```
 
 use std::path::PathBuf;


### PR DESCRIPTION
This makes the build script logic more flexible and configurable by environment variable.