### PR TITLE
polish: Remove redundant attrs on `unchecked_ref_cast_mut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ wstp-sys = { version = "0.2.4", path = "./wstp-sys" }
 wolfram-expr = "0.1.0"
 
 once_cell = "1.9.0"
-ref-cast = "1.0.12"
+ref-cast = "1.0.13"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,6 @@ impl Link {
     ///
     /// * The [`Link`] type is a `#[repr(transparent)]` wrapper around around a
     ///   single field of type [`WSLINK`][crate::sys::WSLINK].
-    #[inline]
     #[ref_cast::ref_cast_custom]
     pub unsafe fn unchecked_ref_cast_mut(from: &mut WSLINK) -> &mut Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,6 @@ impl Link {
     ///   single field of type [`WSLINK`][crate::sys::WSLINK].
     #[inline]
     #[ref_cast::ref_cast_custom]
-    #[allow(unused_unsafe)]
     pub unsafe fn unchecked_ref_cast_mut(from: &mut WSLINK) -> &mut Self;
 }
 


### PR DESCRIPTION
- https://github.com/dtolnay/ref-cast/pull/38 fixes the `unused_unsafe` lint
- https://github.com/dtolnay/ref-cast/pull/39 makes `ref_cast_custom` functions inline by default