### PR TITLE
bugfix: Fix use of i8 instead of c_char causing build failures on Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ mod test_readme {
 
 
 use std::convert::TryFrom;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 use std::fmt::{self, Display};
 use std::net;
 
@@ -516,7 +516,7 @@ impl Link {
     pub fn open_with_args(args: &[&str]) -> Result<Self, Error> {
         // NOTE: Before returning, we must convert these back into CString's to
         //       deallocate them.
-        let mut c_strings: Vec<*mut i8> = args
+        let mut c_strings: Vec<*mut c_char> = args
             .into_iter()
             .map(|&str| {
                 CString::new(str)
@@ -623,7 +623,7 @@ impl Link {
         let Link { raw_link } = *self;
 
         unsafe {
-            let name: *const i8 = self::sys::WSName(raw_link as *mut _);
+            let name: *const c_char = self::sys::WSName(raw_link as *mut _);
             CStr::from_ptr(name).to_str().unwrap().to_owned()
         }
     }
@@ -652,7 +652,7 @@ impl Link {
     pub fn error(&self) -> Option<Error> {
         let Link { raw_link } = *self;
 
-        let (code, message): (i32, *const i8) =
+        let (code, message): (i32, *const c_char) =
             unsafe { (sys::WSError(raw_link), WSErrorMessage(raw_link)) };
 
         if code == sys::MLEOK || message.is_null() {


### PR DESCRIPTION
The code mistakenly assumed that c_char was i8 on all Rust platforms, but that is not true on Linux, so this is causing type mismatch errors at build time on Linux.

(This mistake of mine was presumably reinforced by Rust issue #15823, which is an issue with rustdoc rendering some type aliases in function signatures as the pointed-to type and not by the alias name, which--among other effects--causes CStr::from_raw() and CString::into_raw() to show `i8` in their type signatures instead of `c_char`.)

See also: https://github.com/rust-lang/rust/issues/15823