### PR TITLE
bugfix: Fix broken automatic discovery of wstp.h and libwstp on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ ref-cast = "1.0.13"
 
 [dev-dependencies]
 rand = "0.8.3"
-wolfram-app-discovery = "0.3.0"
+wolfram-app-discovery = "0.4.1"

--- a/wstp-sys/Cargo.toml
+++ b/wstp-sys/Cargo.toml
@@ -18,5 +18,5 @@ links = "WSTPi4"
 link-cplusplus = "1.0.6"
 
 [build-dependencies]
-wolfram-app-discovery = "0.3.0"
+wolfram-app-discovery = "0.4.1"
 bindgen = "0.59.2"


### PR DESCRIPTION
Update to the latest wolfram-app-discovery version, which contains fixes for app discovery on Linux.