### PR TITLE
cleanup: Remove dependency on once_cell

### DIFF
--- a/wstp/Cargo.toml
+++ b/wstp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wstp"
 version = "0.2.8"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.70" # Update to 1.70 for OnceLock
 license = "MIT OR Apache-2.0"
 authors = ["Connor Gray <code@connorgray.com>"]
 readme = "../README.md"
@@ -18,7 +18,6 @@ wstp-sys = { version = "0.2.8", path = "../wstp-sys" }
 
 wolfram-expr = "0.1.4"
 
-once_cell = "1.9.0"
 ref-cast = "1.0.13"
 
 [dev-dependencies]

--- a/wstp/tests/test_link_server.rs
+++ b/wstp/tests/test_link_server.rs
@@ -3,15 +3,13 @@ use std::{
     time::{Duration, Instant},
 };
 
-use once_cell::sync::Lazy;
-
 use wstp::{sys, Link, LinkServer, Protocol};
 
 const PORT: u16 = 11235;
 
 /// Guard used to ensure the [`LinkServer`] tests are run sequentially, so that the
 /// [`PORT`] is free for each test.
-static MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static MUTEX: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_link_server_using_accept() {

--- a/wstp/tests/test_links.rs
+++ b/wstp/tests/test_links.rs
@@ -1,12 +1,10 @@
 use std::sync::Mutex;
 
-use once_cell::sync::Lazy;
-
 use wstp::{sys, Link, Protocol, UrgentMessage};
 
 /// Guard used to ensure the tests which bind to a port are run sequentially, so that
 /// port is free for each test.
-static MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static MUTEX: Mutex<()> = Mutex::new(());
 
 fn random_link_name() -> String {
     use rand::{distributions::Alphanumeric, Rng};


### PR DESCRIPTION
* Replace `stdenv() -> MutexGuard` with with_raw_stdenv() API for enforcing exclusive access to the STDENV instance. Remove the custom StdEnv wrapper type. I think using a scoped callback is a slightly cleaner way to implement this than a StdEnv type with its weird custom Deref impl.