### PR TITLE
test: Add basic test_shutdown.rs tests

### DIFF
--- a/wstp/tests/test_shutdown.rs
+++ b/wstp/tests/test_shutdown.rs
@@ -1,0 +1,15 @@
+use wstp::Link;
+
+// Test that trying to create a link after shutdown() is called causes an error
+// to be returned, instead of a panic.
+#[test]
+fn test_shutdown() {
+    unsafe {
+        wstp::shutdown().unwrap();
+    }
+
+    assert_eq!(
+        Link::new_loopback().unwrap_err().to_string(),
+        "WSTP error: wstp-rs: STDENV has been shutdown. No more links can be created."
+    );
+}


### PR DESCRIPTION
This tests that trying to create a link after shutdown() is called causes an error to be returned, instead of a panic.