### PR TITLE
release: Prep v0.2.9 for release + update CHANGELOG.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@
 ![License](https://img.shields.io/crates/l/wstp.svg)
 [![Documentation](https://docs.rs/wstp/badge.svg)](https://docs.rs/wstp)
 
-<h4>
-  <a href="https://docs.rs/wstp">API Documentation</a>
-  <span> | </span>
-  <a href="https://github.com/WolframResearch/wstp-rs/blob/master/docs/CHANGELOG.md">Changelog</a>
-  <span> | </span>
-  <a href="https://github.com/WolframResearch/wstp-rs/blob/master/docs/CONTRIBUTING.md">Contributing</a>
-</h4>
+#### [API Documentation](https://docs.rs/CRATE-NAME) | [Changelog](./docs/CHANGELOG.md) | [Contributing](./docs/CONTRIBUTING.md)
+
 
 Bindings to the [Wolfram Symbolic Transfer Protocol (WSTP)](https://www.wolfram.com/wstp/).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.2.9] — 2023-10-07
+
+### Fixed
+
+* Support NULL bytes in strings sent via `Link::put_str()`. ([#60])
+
+### Changed
+
+* Update minimum supported Rust version (MSRV) to **Rust 1.70**. Remove
+  dependency on once_cell. ([#62])
+
+
 
 ## [0.2.8] — 2023-08-28
 
@@ -343,10 +355,15 @@ Initial release of the [`wstp`](https://crates.io/crates/wstp) crate.
 [#55]: https://github.com/WolframResearch/wstp-rs/pull/55
 [#56]: https://github.com/WolframResearch/wstp-rs/pull/56
 
+<!-- v0.2.9 -->
+[#60]: https://github.com/WolframResearch/wstp-rs/pull/60
+[#62]: https://github.com/WolframResearch/wstp-rs/pull/62
+
 
 <!-- This needs to be updated for each tagged release. -->
-[Unreleased]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.9...HEAD
 
+[0.2.9]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.7...v0.2.7
 [0.2.6]: https://github.com/WolframResearch/wstp-rs/compare/v0.2.5...v0.2.6

--- a/wstp-sys/Cargo.toml
+++ b/wstp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wstp-sys"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Connor Gray <code@connorgray.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/wstp/Cargo.toml
+++ b/wstp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wstp"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 rust-version = "1.70" # Update to 1.70 for OnceLock
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
* Use Markdown instead of HTML for README.md header bar links.

  This avoids hard-coding in the master branch as the destination for e.g. the Changelog link.