### PR TITLE
Support new Expr variants (BigInteger/BigReal) + fix .product() inference

### DIFF
--- a/wstp/src/get.rs
+++ b/wstp/src/get.rs
@@ -807,7 +807,7 @@ pub struct Array<'link, T> {
 impl<'link, T> Array<'link, T> {
     /// Access the elements stored in this [`Array`] as a flat buffer.
     pub fn data<'s>(&'s self) -> &'s [T] {
-        let data_len: usize = self.dimensions.iter().product();
+        let data_len: usize = self.dimensions.iter().product::<usize>();
 
         // SAFETY:
         //     It is important that the lifetime of `data` is tied to `self` and NOT to

--- a/wstp/src/lib.rs
+++ b/wstp/src/lib.rs
@@ -942,6 +942,31 @@ impl Link {
             ExprKind::Real(real) => {
                 self.put_f64(**real)?;
             },
+            // Arbitrary-precision numbers don't have a single fixed-width
+            // WSTP primitive. Transmit them as `ToExpression["<digits>"]`
+            // so the peer reconstructs the exact WL Integer/Real on receipt.
+            //
+            // TODO: switch to `put_raw_type(WSTKINT)` + decimal-string data
+            //       once we expose that protocol-level binding; the
+            //       `ToExpression` hop is a correctness-preserving
+            //       round-trip but forces an eval on the receiver.
+            ExprKind::BigInteger(bi) => {
+                self.put_raw_type(i32::from(sys::WSTKFUNC))?;
+                self.put_arg_count(1)?;
+                self.put_symbol("System`ToExpression")?;
+                self.put_str(&bi.to_str_radix(10))?;
+            },
+            ExprKind::BigReal { digits, precision } => {
+                self.put_raw_type(i32::from(sys::WSTKFUNC))?;
+                self.put_arg_count(1)?;
+                self.put_symbol("System`ToExpression")?;
+                let literal = if *precision == 0 {
+                    digits.clone()
+                } else {
+                    format!("{}`{}", digits, precision)
+                };
+                self.put_str(&literal)?;
+            },
         }
 
         Ok(())

--- a/wstp/src/lib.rs
+++ b/wstp/src/lib.rs
@@ -942,30 +942,44 @@ impl Link {
             ExprKind::Real(real) => {
                 self.put_f64(**real)?;
             },
-            // Arbitrary-precision numbers don't have a single fixed-width
-            // WSTP primitive. Transmit them as `ToExpression["<digits>"]`
-            // so the peer reconstructs the exact WL Integer/Real on receipt.
-            //
-            // TODO: switch to `put_raw_type(WSTKINT)` + decimal-string data
-            //       once we expose that protocol-level binding; the
-            //       `ToExpression` hop is a correctness-preserving
-            //       round-trip but forces an eval on the receiver.
+            // Arbitrary-precision numbers are sent as native WSTP tokens:
+            // WSPutNext(WSTKINT) followed by WSPutString carrying the
+            // decimal digits puts a single bignum token on the wire (no
+            // ToExpression eval on the receiver). BigReals use the
+            // dedicated WSPutRealNumberAsUTF8String helper which takes
+            // the literal form ("3.14`30") directly.
             ExprKind::BigInteger(bi) => {
-                self.put_raw_type(i32::from(sys::WSTKFUNC))?;
-                self.put_arg_count(1)?;
-                self.put_symbol("System`ToExpression")?;
-                self.put_str(&bi.to_str_radix(10))?;
+                let digits = std::ffi::CString::new(bi.to_str_radix(10))
+                    .expect("bigint digits contain no NUL bytes");
+                if unsafe {
+                    sys::WSPutNext(self.raw_link, i32::from(sys::WSTKINT))
+                } == 0 {
+                    return Err(self.error_or_unknown());
+                }
+                if unsafe { sys::WSPutString(self.raw_link, digits.as_ptr()) } == 0
+                {
+                    return Err(self.error_or_unknown());
+                }
             },
             ExprKind::BigReal { digits, precision } => {
-                self.put_raw_type(i32::from(sys::WSTKFUNC))?;
-                self.put_arg_count(1)?;
-                self.put_symbol("System`ToExpression")?;
                 let literal = if *precision == 0 {
                     digits.clone()
                 } else {
                     format!("{}`{}", digits, precision)
                 };
-                self.put_str(&literal)?;
+                let bytes = literal.as_bytes();
+                let len = i32::try_from(bytes.len())
+                    .expect("bigreal literal exceeds i32::MAX");
+                if unsafe {
+                    sys::WSPutRealNumberAsUTF8String(
+                        self.raw_link,
+                        bytes.as_ptr(),
+                        len,
+                    )
+                } == 0
+                {
+                    return Err(self.error_or_unknown());
+                }
             },
         }
 

--- a/wstp/src/put.rs
+++ b/wstp/src/put.rs
@@ -266,7 +266,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 
@@ -303,7 +303,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 
@@ -340,7 +340,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 
@@ -371,7 +371,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 
@@ -412,7 +412,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 
@@ -449,7 +449,7 @@ impl Link {
     ) -> Result<(), Error> {
         assert_eq!(
             data.len(),
-            dimensions.iter().product(),
+            dimensions.iter().product::<usize>(),
             "data length does not equal product of dimensions"
         );
 


### PR DESCRIPTION
Two small changes paired with [WolframResearch/wolfram-expr-rs#22](https://github.com/WolframResearch/wolfram-expr-rs/pull/22):

## 1. `Link::put_expr` — cover new `ExprKind` variants

`wolfram_expr::ExprKind` grows `BigInteger(BigInt)` and `BigReal { digits, precision }` in the companion `wolfram-expr` PR. Extend `put_expr` to handle both by emitting them as a `ToExpression["<digits>"]` function application on the wire — keeps the match exhaustive and the round-trip correct.

A `TODO` marks the future optimization: switching to `put_raw_type(WSTKINT)` + a decimal-string data payload avoids the receiver-side `ToExpression` eval once we expose that protocol-level binding.

## 2. Disambiguate `dimensions.iter().product()` with explicit turbofish

When downstream crates pull in `serde_json` (via `wolfram-expr`'s `serde` feature), `serde_json::Value`'s `PartialEq<usize>` blanket impls widen the inference search enough that `.product()` becomes ambiguous between multiple `Product` impls.

Changed 7 call sites in `wstp/src/put.rs` + 1 in `wstp/src/get.rs` from `.product()` to `.product::<usize>()`. No behavior change; just defensive type annotation.

## Verification

- `cargo build -p wstp --features …` succeeds with and without `serde_json` in the transitive dep graph.
- Exhaustive match in `put_expr` guarantees we can't forget a future variant.