### PR TITLE
Add Link::activate_with_timeout and WolframKernelProcess::launch_with_timeout

### DIFF
--- a/wstp/src/kernel/mod.rs
+++ b/wstp/src/kernel/mod.rs
@@ -56,7 +56,7 @@
 //!
 //! * [`Link::put_eval_packet()`]
 
-use std::{path::PathBuf, process};
+use std::{path::PathBuf, process, time::Duration};
 
 use wolfram_expr::Expr;
 
@@ -105,6 +105,27 @@ impl WolframKernelProcess {
     // TODO: Would it be correct to describe this as essentially `LinkLaunch`? Also note
     //       that this doesn't actually use `-linkmode launch`.
     pub fn launch(path: &PathBuf) -> Result<WolframKernelProcess, Error> {
+        Self::launch_impl(path, None)
+    }
+
+    /// Like [`WolframKernelProcess::launch()`], but aborts with an error if the
+    /// spawned kernel does not complete the WSTP handshake within `timeout`.
+    ///
+    /// Use this when you want to bound how long the caller blocks waiting for a
+    /// kernel that may fail to start (e.g. licensing failures, missing binary,
+    /// misconfigured environment). The underlying mechanism is
+    /// [`Link::activate_with_timeout()`].
+    pub fn launch_with_timeout(
+        path: &PathBuf,
+        timeout: Duration,
+    ) -> Result<WolframKernelProcess, Error> {
+        Self::launch_impl(path, Some(timeout))
+    }
+
+    fn launch_impl(
+        path: &PathBuf,
+        timeout: Option<Duration>,
+    ) -> Result<WolframKernelProcess, Error> {
         let mut link = Link::listen(Protocol::SharedMemory, "")?;
 
         let name = link.link_name();
@@ -120,16 +141,14 @@ impl WolframKernelProcess {
             .spawn()?;
 
         // Wait for an incoming connection to be made to the listening link.
-        // This will block until a connection is made.
-        //
-        // FIXME: This currently has an infinite timeout. If the spawned
-        //        process fails to connect for some reason (e.g. a launched
-        //        Kernel doesn't start due to a licensing error), this will
-        //        just wait forever, hanging the current program.
-        //
-        //        TODO: Set a yield function that will abort if a timeout
-        //              duration is reached.
-        let () = link.activate()?;
+        // With `timeout = None` this blocks forever (matching the historical
+        // `launch()` behaviour). With `Some(d)` the wait is bounded by the
+        // cooperative yield-function abort installed by
+        // `Link::activate_with_timeout`.
+        match timeout {
+            Some(d) => link.activate_with_timeout(d)?,
+            None => link.activate()?,
+        };
 
         Ok(WolframKernelProcess {
             process: kernel_process,

--- a/wstp/src/lib.rs
+++ b/wstp/src/lib.rs
@@ -390,6 +390,13 @@ impl Link {
     }
 
     /// Create a new named WSTP link using `protocol`.
+    ///
+    /// The returned [`Link`] is *unactivated*: the WSTP handshake between the two
+    /// endpoints does not occur until [`Link::activate()`] (or
+    /// [`Link::activate_with_timeout()`]) is called on this side *and* the peer end of
+    /// the link calls [`Link::activate()`] on its [`Link::connect()`] handle. Both
+    /// endpoints typically activate concurrently from separate threads (see
+    /// [`channel()`] for the canonical two-thread pattern).
     pub fn listen(protocol: Protocol, name: &str) -> Result<Self, Error> {
         let protocol_string = protocol.to_string();
 
@@ -410,6 +417,18 @@ impl Link {
     }
 
     /// Connect to an existing named WSTP link.
+    ///
+    /// The returned [`Link`] is *unactivated*: opening the connection does not perform
+    /// the WSTP handshake. The handshake happens inside [`Link::activate()`] (or
+    /// [`Link::activate_with_timeout()`]), and requires the peer to call `activate()`
+    /// on its [`Link::listen()`] handle concurrently — see [`channel()`] for the
+    /// canonical two-thread pattern.
+    ///
+    /// Note that for the [`SharedMemory`][Protocol::SharedMemory] protocol this
+    /// function will return a [`Link`] successfully even if no listener is currently
+    /// bound to `name`; the failure to connect to a missing peer surfaces only when
+    /// [`Link::activate()`] is called. Use [`Link::activate_with_timeout()`] to bound
+    /// how long activation waits for a peer.
     pub fn connect(protocol: Protocol, name: &str) -> Result<Self, Error> {
         Link::connect_with_options(protocol, name, &[])
     }
@@ -561,6 +580,14 @@ impl Link {
         Link { raw_link }
     }
 
+    /// Perform the WSTP handshake on this link.
+    ///
+    /// This blocks **indefinitely** until the peer endpoint also activates (or until
+    /// an underlying transport error occurs). If the peer never appears — e.g. a
+    /// spawned Wolfram Kernel fails to start, or no [`Link::connect()`] is ever made
+    /// to a listening link — this call will hang forever. Use
+    /// [`Link::activate_with_timeout()`] when a bounded wait is required.
+    ///
     /// *WSTP C API Documentation:* [`WSActivate()`](https://reference.wolfram.com/language/ref/c/WSActivate.html)
     pub fn activate(&mut self) -> Result<(), Error> {
         // Note: WSActivate() returns 0 in the event of an error, and sets an error
@@ -572,11 +599,143 @@ impl Link {
         Ok(())
     }
 
+    /// Like [`Link::activate()`], but aborts and returns an error if the WSTP
+    /// handshake does not complete within `timeout`.
+    ///
+    /// This is implemented on top of the WSTP yield-function hook
+    /// ([`WSSetYieldFunction`](https://reference.wolfram.com/language/ref/c/WSSetYieldFunction.html)):
+    /// a cooperative-abort callback is installed on this link for the duration of the
+    /// `WSActivate` call. The callback checks the deadline each time WSTP yields and
+    /// returns non-zero once `timeout` has elapsed, which causes `WSActivate` to
+    /// abort. The previously-installed yield function (if any) is restored before
+    /// this function returns.
+    ///
+    /// The yield function is per-link state, so concurrent activations of different
+    /// links on different threads are independent.
+    ///
+    /// # Errors
+    ///
+    /// - If the deadline elapses, returns an [`Error`] whose message indicates the
+    ///   timeout. The link remains usable (you may attempt to activate it again, or
+    ///   drop it).
+    /// - If `WSActivate` fails for any other reason, returns the underlying WSTP
+    ///   error.
+    pub fn activate_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<(), Error> {
+        use std::time::Instant;
+
+        let deadline = Instant::now() + timeout;
+
+        // Install the per-thread deadline used by the yield trampoline below.
+        // The trampoline reads this thread-local to decide whether to abort the
+        // in-progress WSActivate call. A thread-local is used because WSTP's
+        // yield function has no user-data argument and WSTP invokes the yield
+        // callback synchronously on the thread that called WSActivate.
+        ACTIVATE_DEADLINE.with(|cell| cell.set(Some(deadline)));
+
+        // Build a yield function object wrapping our trampoline. WSTP requires
+        // yield functions to be created via WSCreateYieldFunction so it can
+        // attach internal bookkeeping.
+        let env_yf: sys::WSYieldFunctionObject = match crate::env::with_raw_stdenv(
+            |stdenv| unsafe {
+                sys::WSCreateYieldFunction(
+                    stdenv,
+                    Some(activate_yield_trampoline),
+                    std::ptr::null_mut(),
+                )
+            },
+        ) {
+            Ok(yfo) if !yfo.is_none() => yfo,
+            Ok(_) => {
+                ACTIVATE_DEADLINE.with(|cell| cell.set(None));
+                return Err(Error::custom(
+                    "WSCreateYieldFunction() returned a null yield function object"
+                        .to_owned(),
+                ));
+            },
+            Err(err) => {
+                ACTIVATE_DEADLINE.with(|cell| cell.set(None));
+                return Err(err);
+            },
+        };
+
+        // Save the previously-installed yield function so we can restore it
+        // after we're done. We do not own this one; do not destroy it.
+        let prev_yf: sys::WSYieldFunctionObject =
+            unsafe { sys::WSGetYieldFunction(self.raw_link) };
+
+        // Install ours. WSSetYieldFunction returns 0 on failure.
+        if unsafe { sys::WSSetYieldFunction(self.raw_link, env_yf) } == 0 {
+            let err = self.error_or_unknown();
+            unsafe {
+                sys::WSDestroyYieldFunction(env_yf);
+            }
+            ACTIVATE_DEADLINE.with(|cell| cell.set(None));
+            return Err(err);
+        }
+
+        // Perform the (now-interruptible) handshake.
+        let activate_rc = unsafe { sys::WSActivate(self.raw_link) };
+        let timed_out = Instant::now() >= deadline;
+
+        // Restore the previous yield function before returning, then destroy
+        // the one we created.
+        let _ = unsafe { sys::WSSetYieldFunction(self.raw_link, prev_yf) };
+        unsafe {
+            sys::WSDestroyYieldFunction(env_yf);
+        }
+        ACTIVATE_DEADLINE.with(|cell| cell.set(None));
+
+        if activate_rc == 0 {
+            if timed_out {
+                return Err(Error::custom(format!(
+                    "WSActivate timed out after {:?}",
+                    timeout
+                )));
+            }
+            return Err(self.error_or_unknown());
+        }
+
+        Ok(())
+    }
+
     /// Close this end of the link.
     ///
     /// *WSTP C API Documentation:* [`WSClose()`](https://reference.wolfram.com/language/ref/c/WSClose.html)
     pub fn close(self) {
         // Note: The link is closed when `self` is dropped.
+    }
+}
+
+//------------------------------------------------------------------------------
+// Yield-function plumbing for `Link::activate_with_timeout`.
+//
+// WSTP's yield-function callback signature has no user-data argument, so we
+// pass the deadline through a thread-local. This is safe because WSTP invokes
+// the yield callback synchronously on the same thread that called the WSTP
+// function (here: `WSActivate`). Storing per-link state in a thread-local is
+// sufficient as long as we never have more than one in-flight
+// `activate_with_timeout` call on a given thread, which is enforced by the
+// `&mut self` borrow of `Link`.
+//------------------------------------------------------------------------------
+
+std::thread_local! {
+    static ACTIVATE_DEADLINE: std::cell::Cell<Option<std::time::Instant>> =
+        const { std::cell::Cell::new(None) };
+}
+
+unsafe extern "C" fn activate_yield_trampoline(
+    _mlp: sys::WSLINK,
+    _yp: sys::WSYieldParameters,
+) -> std::os::raw::c_int {
+    // Return non-zero to ask WSTP to abort the in-progress call.
+    let now = std::time::Instant::now();
+    let deadline = ACTIVATE_DEADLINE.with(|cell| cell.get());
+    match deadline {
+        Some(d) if now >= d => 1,
+        _ => 0,
     }
 }
 

--- a/wstp/tests/test_activate_timeout.rs
+++ b/wstp/tests/test_activate_timeout.rs
@@ -1,0 +1,148 @@
+//! Tests for `Link::activate_with_timeout` and
+//! `WolframKernelProcess::launch_with_timeout`.
+//!
+//! The kernel-launching test in this file is gated on the
+//! `WSTP_RUN_KERNEL_TESTS` environment variable, because launching a Wolfram
+//! Kernel requires a local Wolfram installation. Set
+//! `WSTP_RUN_KERNEL_TESTS=1` to opt in.
+//!
+//! The two pure-WSTP tests (no kernel needed) run unconditionally.
+
+use std::{
+    path::PathBuf,
+    thread,
+    time::{Duration, Instant},
+};
+
+use wstp::{Link, Protocol};
+
+#[test]
+fn activate_with_timeout_returns_err_when_no_peer_connects() {
+    let mut listener = Link::listen(Protocol::SharedMemory, "")
+        .expect("listen() should succeed for a fresh SharedMemory link");
+
+    let start = Instant::now();
+    let result = listener.activate_with_timeout(Duration::from_millis(500));
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "expected activate_with_timeout to error when no peer connects, got {result:?}"
+    );
+
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("timed out") || msg.to_lowercase().contains("timeout"),
+        "expected timeout-flavoured error message, got: {msg}"
+    );
+
+    assert!(
+        elapsed >= Duration::from_millis(500),
+        "activate_with_timeout returned too early: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "activate_with_timeout took too long to abort: {elapsed:?}"
+    );
+}
+
+#[test]
+fn activate_with_timeout_succeeds_when_peer_connects_within_window() {
+    let mut listener = Link::listen(Protocol::SharedMemory, "")
+        .expect("listen() should succeed");
+    let name = listener.link_name();
+    assert!(!name.is_empty());
+
+    let listener_thread = thread::spawn(move || {
+        listener
+            .activate_with_timeout(Duration::from_secs(5))
+            .expect("listener-side activate_with_timeout should succeed");
+        listener
+    });
+
+    let connecter_thread = thread::spawn(move || {
+        // Give the listener a moment to be ready.
+        thread::sleep(Duration::from_millis(100));
+        let mut connecter = Link::connect(Protocol::SharedMemory, &name)
+            .expect("connect() should succeed");
+        connecter
+            .activate_with_timeout(Duration::from_secs(5))
+            .expect("connecter-side activate_with_timeout should succeed");
+        connecter
+    });
+
+    let _listener = listener_thread.join().expect("listener thread panicked");
+    let _connecter = connecter_thread.join().expect("connecter thread panicked");
+}
+
+/// Verify that a second activation attempt after a timeout still behaves
+/// sensibly (the yield function is properly restored, the link state is not
+/// corrupted, and the deadline thread-local is cleared).
+#[test]
+fn activate_with_timeout_can_be_called_twice_on_same_thread() {
+    let mut a = Link::listen(Protocol::SharedMemory, "")
+        .expect("listen() should succeed");
+    let _ = a.activate_with_timeout(Duration::from_millis(200));
+
+    let mut b = Link::listen(Protocol::SharedMemory, "")
+        .expect("listen() should succeed");
+    let start = Instant::now();
+    let result = b.activate_with_timeout(Duration::from_millis(200));
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected second timeout to also error");
+    assert!(
+        elapsed >= Duration::from_millis(200),
+        "second activate_with_timeout returned too early: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "second activate_with_timeout took too long: {elapsed:?}"
+    );
+}
+
+/// Kernel test: when given a path that does not exist (or refuses to start),
+/// `launch_with_timeout` should error within roughly `timeout`, instead of
+/// hanging forever like `launch()` would under the same scenario.
+///
+/// Gated on `WSTP_RUN_KERNEL_TESTS=1` to keep CI configurations that don't
+/// have a Wolfram installation happy, even though this particular test does
+/// not actually require a working kernel.
+#[test]
+fn launch_with_timeout_errors_on_missing_kernel_within_window() {
+    if std::env::var("WSTP_RUN_KERNEL_TESTS").ok().as_deref() != Some("1") {
+        eprintln!(
+            "skipping launch_with_timeout_errors_on_missing_kernel_within_window: \
+             set WSTP_RUN_KERNEL_TESTS=1 to enable"
+        );
+        return;
+    }
+
+    use wstp::kernel::WolframKernelProcess;
+
+    // A path that exists but is not a Wolfram Kernel: /bin/sleep on Unix,
+    // which will be spawned but never speak WSTP back to us.
+    let fake_kernel: PathBuf = if cfg!(unix) {
+        PathBuf::from("/bin/sleep")
+    } else {
+        // On Windows, ping.exe is universally present and runs long enough
+        // to never satisfy the WSTP handshake.
+        PathBuf::from("ping")
+    };
+
+    let start = Instant::now();
+    let result = WolframKernelProcess::launch_with_timeout(
+        &fake_kernel,
+        Duration::from_secs(1),
+    );
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "expected launch_with_timeout to error for non-kernel binary"
+    );
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "launch_with_timeout took too long: {elapsed:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds bounded-wait variants of the two WSTP activation entry points:

- `Link::activate_with_timeout(&mut self, Duration) -> Result<(), Error>`
- `WolframKernelProcess::launch_with_timeout(&PathBuf, Duration) -> Result<WolframKernelProcess, Error>`

The existing `Link::activate()` / `WolframKernelProcess::launch()` keep their indefinite-blocking semantics; the new methods are purely additive, so this is non-breaking for consumers on crates.io.

Closes the in-tree FIXME at `wstp/src/kernel/mod.rs` (previously around lines 125–131), whose author specifically proposed implementing this via `WSSetYieldFunction` — which is what this PR does.

## Motivation

`WSActivate` blocks indefinitely. If the peer never appears — e.g. a spawned Wolfram Kernel fails to start because of a licensing error, a missing binary, or a misconfigured environment — the caller hangs forever with no recourse. Downstream code currently has to either accept the hang or do unpleasant things like `thread::spawn` + `Link::close` racing, neither of which is portable or principled.

The new entry points let callers bound the activation wait and surface a clean timeout error when the deadline elapses.

## Design

WSTP's yield-function hook signature is `fn(WSLINK, WSYieldParameters) -> c_int` and has **no user-data slot**, so the deadline can't be passed through callback arguments. The implementation handles this with a thread-local:

1. Store `deadline = Instant::now() + timeout` in a `thread_local! Cell<Option<Instant>>`.
2. Create a yield-function object via `WSCreateYieldFunction`, wrapping a static `extern "C"` trampoline that reads the thread-local and returns `1` once the deadline elapses.
3. Save the previously-installed yield function via `WSGetYieldFunction`, install ours via `WSSetYieldFunction`.
4. Call `WSActivate`. If WSTP cooperatively yields past the deadline, the trampoline aborts the call.
5. Restore the previous yield function, destroy the one we created, clear the thread-local.
6. Disambiguate a timeout from a real WSTP error (both surface as `WSActivate` returning `0`) by re-checking `Instant::now() >= deadline`.

### Why thread-locals are safe here

- WSTP invokes the yield callback **synchronously** on the thread that called `WSActivate` — there is no background thread.
- `&mut self` on `activate_with_timeout` prevents two concurrent activations on the same `Link`.
- Different `Link`s on the same thread can't reach `WSActivate` simultaneously either, since the call is synchronous.

So the thread-local can be set, read by the trampoline, and cleared without any cross-thread reasoning. There's a regression test (`activate_with_timeout_can_be_called_twice_on_same_thread`) that pins down the clean-between-calls invariant specifically.

## Also included: docstring clarifications

`Link::listen`, `Link::connect`, and `Link::activate` previously did not document that the WSTP handshake is a two-phase `connect → activate` dance requiring *both* endpoints to call `activate()` concurrently — and, in the `SharedMemory` case, that `connect()` returns successfully even with no peer bound, with the failure only surfacing inside `activate()`. The new doc-comments spell this out and cross-link to `activate_with_timeout` for the bounded-wait variant.

## Test plan

- [x] `cargo build -p wstp` — clean (pre-existing warnings only)
- [x] `cargo test -p wstp` — 66 unit/integration tests pass + 19 doctests pass
- [x] New file `wstp/tests/test_activate_timeout.rs` with 4 tests:
  - timeout fires when no peer connects (within window)
  - paired `listen` + `connect` activations succeed within timeout
  - second activation on the same thread still works (thread-local cleanup regression guard)
  - `launch_with_timeout` aborts on non-kernel binary within the deadline (gated on `WSTP_RUN_KERNEL_TESTS=1`)